### PR TITLE
Fix mktemp

### DIFF
--- a/jrun
+++ b/jrun
@@ -145,7 +145,7 @@ test -n "$c" && dep="$dep<classifier>$c</classifier>"
 
 # Synthesize a dummy Maven project.
 
-tmpDir=$(mktemp -d -t jrun)
+tmpDir=$(mktemp -d -t jrunXXX)
 
 for repository in "${repositories[@]}"
 do


### PR DESCRIPTION
`jrun` fails on my machine with:
```
$ ./jrun org.python:jython-standalone
mktemp: too few X's in template ‘jrun’
./jrun: line 161: /pom.xml: Permission denied
./jrun: line 175: /build.log: Permission denied
Failed to bootstrap the artifact. Here is the log:
cat: /build.log: No such file or directory
```
`mktemp` version on my machine:
```
$ mktemp --version
mktemp (GNU coreutils) 8.26
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Jim Meyering and Eric Blake.
```

`jrun` works for me after this fix.