### PR TITLE
Add -B to mvnArgs to disable color output

### DIFF
--- a/jrun
+++ b/jrun
@@ -338,6 +338,7 @@ EOL
 check mvn
 test $updateMaven && mvnArgs=-U
 test "$verbose" = "2" && mvnArgs=-X
+mvnArgs="${mvnArgs} -B"
 goodPOM=$(goodPath "$tmpPOM")
 buildLog=$(test $verbose && set -x; mvn $mvnArgs -f "$goodPOM" dependency:resolve 2>&1)
 if [ $? -ne 0 ]


### PR DESCRIPTION
Adding `-B` to the maven arguments runs it in batch mode, which disables color output of commands.

When color output is enabled, [this line with sed](https://github.com/ctrueden/jrun/blob/3ddde431f6387d76088a12f1eb3fd8f49ff4091d/jrun#L365) does not work as intended, because the coloring information comes after the open bracket and before `INFO`, which causes problems with the symbolic linking.