### PR TITLE
Expand coordinate only from start of string

### DIFF
--- a/jrun/jrun.py
+++ b/jrun/jrun.py
@@ -277,13 +277,15 @@ def default_config():
 
 def expand_coordinate(coordinate, shortcuts={}):
     was_changed = True
+    used_shortcuts = set()
     while was_changed:
         matched_shortcut = False
         for shortcut, replacement in shortcuts.items():
-            if coordinate.startswith(shortcut):
+            if shortcut not in used_shortcuts and coordinate.startswith(shortcut):
                 _logger.debug("Replacing %s with %s in %s.", shortcut, replacement, coordinate)
                 coordinate = coordinate.replace(shortcut, replacement)
                 matched_shortcut = True
+                used_shortcuts.add(shortcut)
         was_changed = matched_shortcut
 
     _logger.debug("Returning expanded coordinate %s.", coordinate)

--- a/jrun/jrun.py
+++ b/jrun/jrun.py
@@ -281,10 +281,12 @@ def expand_coordinate(coordinate, shortcuts={}):
         matched_shortcut = False
         for shortcut, replacement in shortcuts.items():
             if coordinate.startswith(shortcut):
+                _logger.debug("Replacing %s with %s in %s.", shortcut, replacement, coordinate)
                 coordinate = coordinate.replace(shortcut, replacement)
                 matched_shortcut = True
         was_changed = matched_shortcut
 
+    _logger.debug("Returning expanded coordinate %s.", coordinate)
     return coordinate
 
 def autocomplete_main_class(main_class, artifactId, workspace):

--- a/jrun/jrun.py
+++ b/jrun/jrun.py
@@ -276,15 +276,15 @@ def default_config():
     return config
 
 def expand_coordinate(coordinate, shortcuts={}):
-    if coordinate in shortcuts:
-        coordinate = shortcuts[coordinate]
-        was_changed = True
+    was_changed = True
+    while was_changed:
+        matched_shortcut = False
+        for shortcut, replacement in shortcuts.items():
+            if coordinate.startswith(shortcut):
+                coordinate = coordinate.replace(shortcut, replacement)
+                matched_shortcut = True
+        was_changed = matched_shortcut
 
-    split = coordinate.split(':')
-    for i, s in enumerate(split):
-        if s in shortcuts:
-            split[i] = shortcuts[s]
-    coordinate = ':'.join(split)
     return coordinate
 
 def autocomplete_main_class(main_class, artifactId, workspace):


### PR DESCRIPTION
 - do not expand each component separately
 - repeat until no shortcut matches

Fixes #16